### PR TITLE
release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ~
 
+### v0.4.0 (2023-08-04)
+* adds support for "text size" setting and high contrast themes.
+* adds AppThemeInfo; add-ons may extend this class to more easily support Suntimes themes.
+* adds tooltip support for older Android versions.
+* fixes bug where toasts are unreadable on api33+.
+* updates CalculatorProviderContract (v0.5.0).
+* updates AddonHelper; legacy settings fragment identifiers (changed in Suntimes v0.15.2).
+* updates AlarmHelper; support for add-on dismiss challenge.
+* updates CalendarHelper; support for templates (adds contract and patterns).
+* updates build; minSdkVersion 11->14, targetSdkVersion 25->28, support libs updated to 28.0.0.
+* other changes in preparation for future migration to AndroidX libraries; annoations, ContextCompat, ResourcesCompat.
+
 ### v0.3.0 (2022-02-04)
 * adds AlarmHelper; add-ons may define custom alarm events.
 * adds ActionsHelper; add-ons can access user-defined actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ~
 
 ### v0.4.0 (2023-08-04)
-* adds support for "text size" setting and high contrast themes.
-* adds AppThemeInfo; add-ons may extend this class to more easily support Suntimes themes.
+* adds support for "text size" setting and high contrast themes; adds AppThemeInfo helper class.
 * adds tooltip support for older Android versions.
 * fixes bug where toasts are unreadable on api33+.
 * updates CalculatorProviderContract (v0.5.0).
@@ -10,7 +9,7 @@
 * updates AlarmHelper; support for add-on dismiss challenge.
 * updates CalendarHelper; support for templates (adds contract and patterns).
 * updates build; minSdkVersion 11->14, targetSdkVersion 25->28, support libs updated to 28.0.0.
-* other changes in preparation for future migration to AndroidX libraries; annoations, ContextCompat, ResourcesCompat.
+* other changes in preparation for future migration to AndroidX libraries; annotations, ContextCompat, ResourcesCompat.
 
 ### v0.3.0 (2022-02-04)
 * adds AlarmHelper; add-ons may define custom alarm events.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         minSdkVersion 14
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 28
-        versionCode 3
-        versionName "0.3.0"
+        versionCode 4
+        versionName "0.4.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/suntimesaddon/build.gradle
+++ b/suntimesaddon/build.gradle
@@ -7,8 +7,8 @@ android {
         minSdkVersion 14
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 28
-        versionCode 3
-        versionName "0.3.0"
+        versionCode 4
+        versionName "0.4.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
@@ -45,7 +45,7 @@ publishing {
         release(MavenPublication) {
             groupId 'com.forrestguice.suntimesaddon'
             artifactId 'suntimesaddon'
-            version '0.3.0'
+            version '0.4.0'
             artifact(sourceJar)
             artifact ("$buildDir/outputs/aar/suntimesaddon-release.aar") {
                 builtBy assemble


### PR DESCRIPTION
* adds support for "text size" setting and high contrast themes; adds AppThemeInfo helper class.
* adds tooltip support for older Android versions.
* fixes bug where toasts are unreadable on api33+.
* updates CalculatorProviderContract (v0.5.0).
* updates AddonHelper; legacy settings fragment identifiers (changed in Suntimes v0.15.2).
* updates AlarmHelper; support for add-on dismiss challenge.
* updates CalendarHelper; support for templates (adds contract and patterns).
* updates build; minSdkVersion 11->14, targetSdkVersion 25->28, support libs updated to 28.0.0.
* other changes in preparation for future migration to AndroidX libraries; annotations, ContextCompat, ResourcesCompat.