### PR TITLE
release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ~
 
+### v0.4.1 (2025-03-07)
+* adds 'supportlib' and 'androidx' build flavors.
+* updates targetSdk 28 -> 33 (androidx flavor).
+* updates agp 3.6.0 -> 4.1.3 (androidx flavor).
+* updates support dependencies (androidx flavor).
+* updates gradle-wrapper 5.6.4 -> 6.5.
+* removes jcenter from the build.
+
 ### v0.4.0 (2023-08-04)
 * adds support for "text size" setting and high contrast themes; adds AppThemeInfo helper class.
 * adds tooltip support for older Android versions.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ private SuntimesInfo suntimesInfo = null;
 
 ### Legal Stuff
 
-Copyright © 2020 Forrest Guice
+Copyright © 2020-2025 Forrest Guice
 
 Source code is available under GPLv3 (https://github.com/forrestguice/SuntimesAddon).
 

--- a/suntimesaddon/build.gradle
+++ b/suntimesaddon/build.gradle
@@ -115,7 +115,7 @@ publishing {
         release(MavenPublication) {
             groupId 'com.forrestguice.suntimesaddon'
             artifactId 'suntimesaddon'
-            version '0.4.0'
+            version '0.4.1'
             artifact(sourceJar)
             artifact ("$buildDir/outputs/aar/suntimesaddon-release.aar") {
                 builtBy assemble

--- a/suntimesaddon/build.gradle
+++ b/suntimesaddon/build.gradle
@@ -7,8 +7,8 @@ android {
         minSdkVersion 14
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 28
-        versionCode 4
-        versionName "0.4.0"
+        versionCode 5
+        versionName "0.4.1"
     }
 
     buildTypes {


### PR DESCRIPTION
* adds 'supportlib' and 'androidx' build flavors.
* updates targetSdk 28 -> 33 (androidx flavor).
* updates agp 3.6.0 -> 4.1.3 (androidx flavor).
* updates support dependencies (androidx flavor).
* updates gradle-wrapper 5.6.4 -> 6.5.
* removes jcenter from the build.