### PR TITLE
release 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ~
 
+### v0.4.3 (2025-06-01)
+* adds 'targetVersion' project variable that filters build flavors (defaults to 33).
+* adds <queries> declaration to AndroidManifest.xml (api30, api33).
+* updates agp 4.1.3 -> 7.2.2 (api33).
+* updates test dependencies (api33).
+* updates gradle-wrapper 6.5 -> 7.3.3.
+
 ### v0.4.2 (2025-03-29)
 * adds "compass intent" definitions for interactions with compass apps.
 * fixes bug where "menu icons are not shown" (androidx).

--- a/suntimesaddon/build.gradle
+++ b/suntimesaddon/build.gradle
@@ -7,8 +7,8 @@ android {
         minSdkVersion 14
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 28
-        versionCode 6
-        versionName "0.4.2"
+        versionCode 7
+        versionName "0.4.3"
     }
 
     buildTypes {
@@ -137,7 +137,7 @@ publishing {
         release(MavenPublication) {
             groupId 'com.forrestguice.suntimesaddon'
             artifactId 'suntimesaddon'
-            version '0.4.2'
+            version '0.4.3'
             artifact(sourceJar)
             artifact ("$buildDir/outputs/aar/suntimesaddon-release.aar") {
                 builtBy assemble


### PR DESCRIPTION
* adds `targetVersion` project variable that filters build flavors (defaults to 33).
* adds `<queries>` declaration to AndroidManifest.xml (api30, api33).
* updates agp 4.1.3 -> 7.2.2 (api33).
* updates test dependencies (api33).
* updates gradle-wrapper 6.5 -> 7.3.3.