### PR TITLE
release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ~
 
+### v0.5.0 (2026-04-08)
+* adds `BootCompletedReceiver`, `BootCompletedService`, and `Notification` helpers.
+* adds `crash report` notification / activity.
+* adds helper methods for the `Event List` activity.
+* adds support for nightly versions.
+* updates CalculatorProviderContract to 8 (0.6.1).
+* updates build; support for targetSdKVersion 34; update gradle-wrapper (8.7), updates agp version (8.5.2).
+
 ### v0.4.3 (2025-06-01)
 * adds 'targetVersion' project variable that filters build flavors (defaults to 33).
 * adds <queries> declaration to AndroidManifest.xml (api30, api33).

--- a/suntimesaddon/build.gradle
+++ b/suntimesaddon/build.gradle
@@ -17,8 +17,8 @@ android {
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 28
 
-        versionCode 7
-        versionName "0.4.3"
+        versionCode 8
+        versionName "0.5.0"
     }
 
     buildTypes {
@@ -208,7 +208,7 @@ publishing {
         release(MavenPublication) {
             groupId 'com.forrestguice.suntimesaddon'
             artifactId 'suntimesaddon'
-            version '0.4.3'
+            version '0.5.0'
             artifact(sourceJar)
             artifact ("$buildDir/outputs/aar/suntimesaddon-release.aar") {
                 builtBy assemble


### PR DESCRIPTION
* adds `BootCompletedReceiver`, `BootCompletedService`, and `Notification` helpers.
* adds `crash report` notification / activity.
* adds helper methods for the `Event List` activity.
* adds support for nightly versions.
* updates CalculatorProviderContract to 8 (0.6.1).
* updates build; support for targetSdKVersion 34; update gradle-wrapper (8.7), updates agp version (8.5.2).